### PR TITLE
Fix SpMV correctness issues

### DIFF
--- a/spmv/run_spmv.jl
+++ b/spmv/run_spmv.jl
@@ -56,7 +56,7 @@ for mtx in datasets[parsed_args["dataset"]]
             rm(key * "_results.txt", force=true)
             open(key * "_results.txt","a") do io
                 for i = 1:n
-                    @printf(io,"%f\n", res.y[1][i])
+                    @printf(io,"%f\n", res.y[i])
                 end
             end
         =#


### PR DESCRIPTION
- Masks were in the wrong direction (albeit in commented out code)
- Re-add mask for diagonals 
- Indexing issue in test harness because we are no longer returning `y` as a tuple in `spmv_finch` and `spmv_julia`